### PR TITLE
Fix comment typo

### DIFF
--- a/src/torrlang.erl
+++ b/src/torrlang.erl
@@ -3,7 +3,7 @@
 
 % Torrlang
 %
-% A Torrent cleint written in Erlang, as an exercise to learn erlang
+% A Torrent client written in Erlang, as an exercise to learn erlang
 
 test() ->
   trackers:start(),


### PR DESCRIPTION
In order to run the client efficiently (for developer time), the comments of the source code that runs that client need to be accurate and up to date.

This patch corrects an erroneous typo ("cleint").